### PR TITLE
Update Chapter_02_Instructions.md

### DIFF
--- a/Chapter-Instructions/Chapter_02_Instructions.md
+++ b/Chapter-Instructions/Chapter_02_Instructions.md
@@ -27,8 +27,8 @@ x <- 3 * 4
 
 Note that the value of x is not printed, it is just stored. If you want
 to view the value, type x in the console. (**Hint**: you can also
-highlight the object name by double clicking and pressing command +
-enter. another simple way, type the object name and run the line)
+highlight the object name by double-clicking and pressing Command +
+Enter. Another simple way, type the object name and run the line)
 
 You can combine multiple elements into a vector with c():
 


### PR DESCRIPTION
 Capitalized "Command" and "Enter", because they are the names of the keys. Also capitalized "Another" because it was following a period. Added a hyphen to "double-clicking".